### PR TITLE
Cache stuff in linear models when doing forward/backward passes

### DIFF
--- a/src/main/scala/com/picnicml/doddlemodel/base/Regressor.scala
+++ b/src/main/scala/com/picnicml/doddlemodel/base/Regressor.scala
@@ -10,8 +10,11 @@ abstract class Regressor[A <: Regressor[A]] extends Predictor[A] {
   override def fit(x: Features, y: Target): A = {
     require(!this.isFitted, "Called fit on a model that is already trained")
     require(this.targetVariableAppropriate(y), "Target variable contains invalid data")
-    this.fitSafe(x, y)
+    this.copy.fitSafe(x, y)
   }
+
+  /** A function that creates an identical regressor. */
+  protected def copy: A
 
   /** A function that checks whether the target variable contains valid data. */
   protected def targetVariableAppropriate(y: Target): Boolean

--- a/src/main/scala/com/picnicml/doddlemodel/dummy/regression/MeanRegressor.scala
+++ b/src/main/scala/com/picnicml/doddlemodel/dummy/regression/MeanRegressor.scala
@@ -13,6 +13,8 @@ import com.picnicml.doddlemodel.data.{Features, Target}
 @SerialVersionUID(1L)
 class MeanRegressor private (val mean: Option[Double]) extends Regressor[MeanRegressor] with Serializable {
 
+  override protected def copy: MeanRegressor = this
+
   override def isFitted: Boolean = this.mean.isDefined
 
   override protected def targetVariableAppropriate(y: Target): Boolean = true

--- a/src/main/scala/com/picnicml/doddlemodel/dummy/regression/MedianRegressor.scala
+++ b/src/main/scala/com/picnicml/doddlemodel/dummy/regression/MedianRegressor.scala
@@ -13,6 +13,8 @@ import com.picnicml.doddlemodel.data.{Features, Target}
 @SerialVersionUID(1L)
 class MedianRegressor private (val median: Option[Double]) extends Regressor[MedianRegressor] with Serializable {
 
+  override protected def copy: MedianRegressor = this
+
   override def isFitted: Boolean = this.median.isDefined
 
   override protected def targetVariableAppropriate(y: Target): Boolean = true

--- a/src/test/scala/com/picnicml/doddlemodel/linear/LinearRegressorTest.scala
+++ b/src/test/scala/com/picnicml/doddlemodel/linear/LinearRegressorTest.scala
@@ -9,6 +9,8 @@ class LinearRegressorTest extends FlatSpec with Matchers {
   private class DummyLinearRegressor(val w: Option[RealVector])
     extends LinearRegressor[DummyLinearRegressor] with Serializable {
 
+    override protected def copy: DummyLinearRegressor = this
+
     override protected def copy(w: RealVector): DummyLinearRegressor = new DummyLinearRegressor(Some(w))
 
     override protected def targetVariableAppropriate(y: Target): Boolean = true


### PR DESCRIPTION
<!-- This is a pull request template. Please fill in the relevant details in the sections below. -->
##### Description of Changes
<!-- Don't forget to add reference to an existing issue if present. -->
calling `lossGrad` after `loss` requires the same call to `predX(...)` in all cases.

##### Includes
<!-- Mark the changes included in the PR. -->
- [X] Code changes
- [ ] Tests
- [ ] Documentation
