### PR TITLE
Add additional classification (F1, Hamming loss) and regression (MSE) metrics

### DIFF
--- a/src/main/scala/io/picnicml/doddlemodel/metrics/ClassificationMetrics.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/metrics/ClassificationMetrics.scala
@@ -42,4 +42,30 @@ object ClassificationMetrics {
       numTp / (numTp + (!yPredPositive &:& yPositive).activeSize.toDouble)
     }
   }
+
+  /** F1 score. */
+  object F1Score extends Metric {
+
+    override lazy val higherValueIsBetter: Boolean = true
+
+    override def apply(y: Target, yPred: Target): Double = {
+      require(y.length == yPred.length, "Target vectors need to be of equal length")
+      require(numberOfTargetClasses(y) == 2, "F1 score is defined for a binary classification task")
+      val prec = precision(y, yPred)
+      val rec = recall(y, yPred)
+
+      2 * (prec * rec) / (prec + rec)
+    }
+  }
+
+  /** Hamming loss. */
+  object HammingLoss extends Metric {
+
+    override lazy val higherValueIsBetter: Boolean = false
+
+    override def apply(y: Target, yPred: Target): Double = {
+      require(y.length == yPred.length, "Target vectors need to be of equal length")
+      1.0 - accuracy(y, yPred)
+    }
+  }
 }

--- a/src/main/scala/io/picnicml/doddlemodel/metrics/ClassificationMetrics.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/metrics/ClassificationMetrics.scala
@@ -54,7 +54,7 @@ object ClassificationMetrics {
       val prec = precision(y, yPred)
       val rec = recall(y, yPred)
 
-      2 * (prec * rec) / (prec + rec)
+      2.0 * (prec * rec) / (prec + rec)
     }
   }
 

--- a/src/main/scala/io/picnicml/doddlemodel/metrics/ClassificationMetrics.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/metrics/ClassificationMetrics.scala
@@ -9,7 +9,7 @@ object ClassificationMetrics {
 
     override lazy val higherValueIsBetter: Boolean = true
 
-    override def apply(y: Target, yPred: Target): Double =
+    override def calculateValueSafe(y: Target, yPred: Target): Double =
       (y :== yPred).activeSize / y.length.toDouble
   }
 
@@ -18,8 +18,12 @@ object ClassificationMetrics {
 
     override lazy val higherValueIsBetter: Boolean = true
 
-    override def apply(y: Target, yPred: Target): Double = {
+    override def checkInput(y: Target, yPred: Target): Unit = {
+      super.checkInput(y, yPred)
       require(numberOfTargetClasses(y) == 2, "Precision is defined for a binary classification task")
+    }
+
+    override def calculateValueSafe(y: Target, yPred: Target): Double = {
       val yPredPositive = yPred :== 1.0
       val yPositive = y :== 1.0
 
@@ -33,8 +37,12 @@ object ClassificationMetrics {
 
     override lazy val higherValueIsBetter: Boolean = true
 
-    override def apply(y: Target, yPred: Target): Double = {
+    override def checkInput(y: Target, yPred: Target): Unit = {
+      super.checkInput(y, yPred)
       require(numberOfTargetClasses(y) == 2, "Recall is defined for a binary classification task")
+    }
+
+    override def calculateValueSafe(y: Target, yPred: Target): Double = {
       val yPredPositive = yPred :== 1.0
       val yPositive = y :== 1.0
 
@@ -48,9 +56,12 @@ object ClassificationMetrics {
 
     override lazy val higherValueIsBetter: Boolean = true
 
-    override def apply(y: Target, yPred: Target): Double = {
-      require(y.length == yPred.length, "Target vectors need to be of equal length")
+    override def checkInput(y: Target, yPred: Target): Unit = {
+      super.checkInput(y, yPred)
       require(numberOfTargetClasses(y) == 2, "F1 score is defined for a binary classification task")
+    }
+
+    override def calculateValueSafe(y: Target, yPred: Target): Double = {
       val prec = precision(y, yPred)
       val rec = recall(y, yPred)
 
@@ -63,9 +74,6 @@ object ClassificationMetrics {
 
     override lazy val higherValueIsBetter: Boolean = false
 
-    override def apply(y: Target, yPred: Target): Double = {
-      require(y.length == yPred.length, "Target vectors need to be of equal length")
-      1.0 - accuracy(y, yPred)
-    }
+    override def calculateValueSafe(y: Target, yPred: Target): Double = 1.0 - accuracy(y, yPred)
   }
 }

--- a/src/main/scala/io/picnicml/doddlemodel/metrics/Metric.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/metrics/Metric.scala
@@ -6,5 +6,14 @@ trait Metric {
 
   val higherValueIsBetter: Boolean
 
-  def apply(y: Target, yPred: Target): Double
+  def checkInput(y: Target, yPred: Target): Unit = {
+    require(y.length == yPred.length, "Target vectors need to be of equal length")
+  }
+
+  def calculateValueSafe(y: Target, yPred: Target): Double
+
+  def apply(y: Target, yPred: Target): Double = {
+    checkInput(y, yPred)
+    calculateValueSafe(y, yPred)
+  }
 }

--- a/src/main/scala/io/picnicml/doddlemodel/metrics/RankingMetrics.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/metrics/RankingMetrics.scala
@@ -10,7 +10,7 @@ object RankingMetrics {
 
     override lazy val higherValueIsBetter: Boolean = true
 
-    override def apply(y: Target, yPredProba: RealVector): Double = {
+    override def calculateValueSafe(y: Target, yPredProba: Target): Double = {
       val roc = rocCurve(y, yPredProba)
       // integrate with the trapezoid rule
       (1 until roc.thresholds.length).foldLeft(0.0) { case (integral, index) =>

--- a/src/main/scala/io/picnicml/doddlemodel/metrics/RegressionMetrics.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/metrics/RegressionMetrics.scala
@@ -12,9 +12,18 @@ object RegressionMetrics {
 
     override lazy val higherValueIsBetter: Boolean = false
 
+    override def apply(y: Target, yPred: Target): Double = sqrt(mse(y, yPred))
+  }
+
+  /** Mean squared error. */
+  object Mse extends Metric {
+
+    override lazy val higherValueIsBetter: Boolean = false
+
     override def apply(y: Target, yPred: Target): Double = {
-      val d = y - yPred
-      sqrt((d.t * d) / y.length.toDouble)
+      require(y.length == yPred.length, "Target vectors need to be of equal length")
+      val diff = y - yPred
+      (diff.t * diff) / y.length.toDouble
     }
   }
 

--- a/src/main/scala/io/picnicml/doddlemodel/metrics/RegressionMetrics.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/metrics/RegressionMetrics.scala
@@ -12,7 +12,7 @@ object RegressionMetrics {
 
     override lazy val higherValueIsBetter: Boolean = false
 
-    override def apply(y: Target, yPred: Target): Double = sqrt(mse(y, yPred))
+    override def calculateValueSafe(y: Target, yPred: Target): Double = sqrt(mse(y, yPred))
   }
 
   /** Mean squared error. */
@@ -20,8 +20,7 @@ object RegressionMetrics {
 
     override lazy val higherValueIsBetter: Boolean = false
 
-    override def apply(y: Target, yPred: Target): Double = {
-      require(y.length == yPred.length, "Target vectors need to be of equal length")
+    override def calculateValueSafe(y: Target, yPred: Target): Double = {
       val diff = y - yPred
       (diff.t * diff) / y.length.toDouble
     }
@@ -32,7 +31,7 @@ object RegressionMetrics {
 
     override lazy val higherValueIsBetter: Boolean = false
 
-    override def apply(y: Target, yPred: Target): Double = sum(abs(y - yPred)) / y.length.toDouble
+    override def calculateValueSafe(y: Target, yPred: Target): Double = sum(abs(y - yPred)) / y.length.toDouble
   }
 
 
@@ -41,6 +40,6 @@ object RegressionMetrics {
 
     override lazy val higherValueIsBetter: Boolean = true
 
-    override def apply(y: Target, yPred: Target): Double = 1.0 - variance(y - yPred) / variance(y)
+    override def calculateValueSafe(y: Target, yPred: Target): Double = 1.0 - variance(y - yPred) / variance(y)
   }
 }

--- a/src/main/scala/io/picnicml/doddlemodel/metrics/package.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/metrics/package.scala
@@ -16,7 +16,7 @@ package object metrics {
   lazy val accuracy: Metric = Accuracy
   lazy val precision: Metric = Precision
   lazy val recall: Metric = Recall
-  lazy val f1score: Metric = F1Score
+  lazy val f1Score: Metric = F1Score
   lazy val hammingLoss: Metric = HammingLoss
 
   // ranking metrics

--- a/src/main/scala/io/picnicml/doddlemodel/metrics/package.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/metrics/package.scala
@@ -7,6 +7,7 @@ import io.picnicml.doddlemodel.metrics.RegressionMetrics._
 package object metrics {
 
   // regression metrics
+  lazy val mse: Metric = Mse
   lazy val rmse: Metric = Rmse
   lazy val mae: Metric = Mae
   lazy val explainedVariance: Metric = ExplainedVariance

--- a/src/main/scala/io/picnicml/doddlemodel/metrics/package.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/metrics/package.scala
@@ -15,6 +15,8 @@ package object metrics {
   lazy val accuracy: Metric = Accuracy
   lazy val precision: Metric = Precision
   lazy val recall: Metric = Recall
+  lazy val f1score: Metric = F1Score
+  lazy val hammingLoss: Metric = HammingLoss
 
   // ranking metrics
   lazy val auc: Metric = Auc

--- a/src/test/scala/io/picnicml/doddlemodel/metrics/ClassificationMetricsTest.scala
+++ b/src/test/scala/io/picnicml/doddlemodel/metrics/ClassificationMetricsTest.scala
@@ -30,7 +30,7 @@ class ClassificationMetricsTest extends FlatSpec with Matchers {
     val y = DenseVector(1.0, 0.0, 0.0, 0.0, 1.0)
     val yPred = DenseVector(1.0, 1.0, 0.0, 1.0, 0.0)
 
-    f1score(y, yPred) shouldBe 0.4
+    f1Score(y, yPred) shouldBe 0.4
   }
 
   they should "calculate a correct Hamming loss value" in {

--- a/src/test/scala/io/picnicml/doddlemodel/metrics/ClassificationMetricsTest.scala
+++ b/src/test/scala/io/picnicml/doddlemodel/metrics/ClassificationMetricsTest.scala
@@ -25,4 +25,19 @@ class ClassificationMetricsTest extends FlatSpec with Matchers {
 
     recall(y, yPred) shouldBe 0.5
   }
+
+  they should "calculate a correct F1 score value" in {
+    val y = DenseVector(1.0, 0.0, 0.0, 0.0, 1.0)
+    val yPred = DenseVector(1.0, 1.0, 0.0, 1.0, 0.0)
+
+    f1score(y, yPred) shouldBe 0.4
+  }
+
+  they should "calculate a correct Hamming loss value" in {
+    val y = DenseVector(1.0, 0.0, 0.0, 0.0, 1.0)
+    val yPred = DenseVector(1.0, 1.0, 0.0, 1.0, 0.0)
+
+    // 3 out of 5 miss-classifications
+    hammingLoss(y, yPred) shouldBe 0.6
+  }
 }

--- a/src/test/scala/io/picnicml/doddlemodel/metrics/RegressionMetricsTest.scala
+++ b/src/test/scala/io/picnicml/doddlemodel/metrics/RegressionMetricsTest.scala
@@ -12,6 +12,13 @@ class RegressionMetricsTest extends FlatSpec with Matchers {
     rmse(y, yPred) shouldEqual 3.076686529368892
   }
 
+  they should "calculate a correct mse value" in {
+    val y = DenseVector(1.0, 4.1, 2.2, 5.1, 9.6)
+    val yPred = DenseVector(1.2, 1.4, 8.2, 3.1, 9.6)
+
+    mse(y, yPred) shouldEqual 9.466 +- 0.001
+  }
+
   they should "calculate a correct mae value" in {
     val y = DenseVector(1.0, 4.1, 2.2, 5.1, 9.6)
     val yPred = DenseVector(1.2, 1.9, 2.8, 4.1, 10.6)


### PR DESCRIPTION
<!-- This is a pull request template. Please fill in the relevant details in the sections below. -->
##### Description of Changes
<!-- Don't forget to add reference to an existing issue if present. -->
Adds a few new classification (F1 score, Hamming loss) and regression (MSE) metrics + tests. I've also changed RMSE so that it reuses the MSE functionality.     
Partially implements #12.

##### Includes
<!-- Mark the changes included in the PR. -->
- [X] Code changes
- [X] Tests
- [ ] Documentation

##### Note
I'm not sure if the checks for inputs (`y` and `yPred`) being of equal length are necessary (not sure how rigorously input should be checked). If they stay in, they should probably also be added to other metrics. 