### PR TITLE
Additional preprocessors

### DIFF
--- a/src/main/scala/io/picnicml/doddlemodel/preprocessing/Binarizer.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/preprocessing/Binarizer.scala
@@ -1,0 +1,38 @@
+package io.picnicml.doddlemodel.preprocessing
+
+import breeze.linalg.{*, DenseVector}
+import io.picnicml.doddlemodel.data.Feature.FeatureIndex
+import io.picnicml.doddlemodel.data.{Features, RealVector}
+import io.picnicml.doddlemodel.typeclasses.Transformer
+
+case class Binarizer private (private val thresholds: RealVector,
+                              private val featureIndex: FeatureIndex)
+
+object Binarizer {
+
+  def apply(threshold: Double, featureIndex: FeatureIndex): Binarizer = {
+    val numNumeric: Int = featureIndex.numerical.columnIndices.length
+    require(numNumeric > 0, "There must be at least 1 numeric column in the given data")
+    val thresholdsExtended = DenseVector.fill(numNumeric) {threshold}
+    new Binarizer(thresholdsExtended, featureIndex)
+  }
+
+  def apply(thresholds: RealVector, featureIndex: FeatureIndex): Binarizer = {
+    val numNumeric = featureIndex.numerical.columnIndices.length
+    require(numNumeric > 0, "There must be at least 1 numeric column in the given data")
+    require(numNumeric == thresholds.length, "A threshold should be given for every numerical column")
+    new Binarizer(thresholds, featureIndex)
+  }
+
+  implicit lazy val ev: Transformer[Binarizer] = new Transformer[Binarizer] {
+
+    override def fit(model: Binarizer, x: Features): Binarizer = model
+
+    override protected def transformSafe(model: Binarizer, x: Features): Features = {
+      val numericColsOnly = x(::, model.featureIndex.numerical.columnIndices).toDenseMatrix
+      (numericColsOnly(*, ::) >:> model.thresholds).mapValues((v: Boolean) => if (v) 1.0 else 0.0)
+    }
+
+    override def isFitted(model: Binarizer): Boolean = true
+  }
+}

--- a/src/main/scala/io/picnicml/doddlemodel/preprocessing/Binarizer.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/preprocessing/Binarizer.scala
@@ -1,20 +1,47 @@
 package io.picnicml.doddlemodel.preprocessing
 
-import breeze.linalg.{*, DenseVector}
+import breeze.linalg.DenseVector
 import io.picnicml.doddlemodel.data.Feature.FeatureIndex
 import io.picnicml.doddlemodel.data.{Features, RealVector}
 import io.picnicml.doddlemodel.typeclasses.Transformer
 
-case class Binarizer private (private val thresholds: RealVector, private val featureIndex: FeatureIndex) {
+case class Binarizer(private val thresholds: RealVector, private val featureIndex: FeatureIndex) {
   private val numNumeric = featureIndex.numerical.columnIndices.length
   require(numNumeric == 0 || numNumeric == thresholds.length, "A threshold should be given for every numerical column")
 }
 
+/** An immutable preprocessor that binarizes numerical features according to a threshold.
+  * Numerical feature values that are greater than the threshold are set to `1.0`, while those that are lower or equal
+  * are set to `0.0`. Non-numerical features are left untouched.
+  * */
 object Binarizer {
 
+  /** Create a binarizer where a single threshold is applied to all numerical columns.
+    *
+    * @param threshold threshold to be applied
+    * @param featureIndex feature index associated with features - this is needed so that only numerical features are
+    *                     transformed by this preprocessor; could be a subset of columns to be transformed
+    *
+    * @example Binarize a matrix with two features: one numerical and one categorical.
+    *   {{{
+    *     import io.picnicml.doddlemodel.preprocessing.Binarizer.ev
+    *
+    *     val featureIndex = FeatureIndex(List(NumericalFeature, CategoricalFeature))
+    *     val x = DenseMatrix(
+    *       List(1.0, 0.0),
+    *       List(-1.0, 1.0),
+    *       List(2.0, 0.0)
+    *     )
+    *     // equivalently, DenseVector(0.0) could be used
+    *     val threshold = 0.0
+    *     val binarizer = Binarizer(threshold, featureIndex)
+    *     // Note: no fitting required
+    *     val xTransformed = ev.transform(binarizer, x)
+    *   }}}
+    */
   def apply(threshold: Double, featureIndex: FeatureIndex): Binarizer = {
     val numNumeric: Int = featureIndex.numerical.columnIndices.length
-    val thresholdsExtended = DenseVector.fill(numNumeric) {threshold}
+    val thresholdsExtended = DenseVector.fill(numNumeric) { threshold }
     Binarizer(thresholdsExtended, featureIndex)
   }
 
@@ -26,12 +53,11 @@ object Binarizer {
 
     override protected def transformSafe(model: Binarizer, x: Features): Features = {
       val xCopy = x.copy
-      val numericColIndices = model.featureIndex.numerical.columnIndices
-      // only perform binarization if there are numerical columns, otherwise keep input
-      if(numericColIndices.nonEmpty) {
-        val numericColsOnly = x(::, numericColIndices).toDenseMatrix
-        xCopy(::, numericColIndices) := (numericColsOnly(*, ::) >:> model.thresholds).mapValues((v: Boolean) =>
-          if (v) 1.0 else 0.0)
+      model.featureIndex.numerical.columnIndices.zipWithIndex.foreach {
+        case (colIndex, thresholdIndex) => (0 until xCopy.rows).foreach {
+          rowIndex =>
+            xCopy(rowIndex, colIndex) = if (xCopy(rowIndex, colIndex) > model.thresholds(thresholdIndex)) 1.0 else 0.0
+        }
       }
 
       xCopy

--- a/src/main/scala/io/picnicml/doddlemodel/preprocessing/Binarizer.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/preprocessing/Binarizer.scala
@@ -5,34 +5,36 @@ import io.picnicml.doddlemodel.data.Feature.FeatureIndex
 import io.picnicml.doddlemodel.data.{Features, RealVector}
 import io.picnicml.doddlemodel.typeclasses.Transformer
 
-case class Binarizer private (private val featureIndex: FeatureIndex,
-                              private val thresholds: RealVector)
+case class Binarizer private (private val thresholds: RealVector, private val featureIndex: FeatureIndex) {
+  private val numNumeric = featureIndex.numerical.columnIndices.length
+  require(numNumeric == 0 || numNumeric == thresholds.length, "A threshold should be given for every numerical column")
+}
 
 object Binarizer {
 
   def apply(threshold: Double, featureIndex: FeatureIndex): Binarizer = {
     val numNumeric: Int = featureIndex.numerical.columnIndices.length
-    require(numNumeric > 0, "There must be at least 1 numeric column in the given data")
     val thresholdsExtended = DenseVector.fill(numNumeric) {threshold}
-    new Binarizer(featureIndex, thresholdsExtended)
-  }
-
-  def apply(thresholds: RealVector, featureIndex: FeatureIndex): Binarizer = {
-    val numNumeric = featureIndex.numerical.columnIndices.length
-    require(numNumeric > 0, "There must be at least 1 numeric column in the given data")
-    require(numNumeric == thresholds.length, "A threshold should be given for every numerical column")
-    new Binarizer(featureIndex, thresholds)
+    Binarizer(thresholdsExtended, featureIndex)
   }
 
   implicit lazy val ev: Transformer[Binarizer] = new Transformer[Binarizer] {
 
+    override def isFitted(model: Binarizer): Boolean = true
+
     override def fit(model: Binarizer, x: Features): Binarizer = model
 
     override protected def transformSafe(model: Binarizer, x: Features): Features = {
-      val numericColsOnly = x(::, model.featureIndex.numerical.columnIndices).toDenseMatrix
-      (numericColsOnly(*, ::) >:> model.thresholds).mapValues((v: Boolean) => if (v) 1.0 else 0.0)
-    }
+      val xCopy = x.copy
+      val numericColIndices = model.featureIndex.numerical.columnIndices
+      // only perform binarization if there are numerical columns, otherwise keep input
+      if(numericColIndices.nonEmpty) {
+        val numericColsOnly = x(::, numericColIndices).toDenseMatrix
+        xCopy(::, numericColIndices) := (numericColsOnly(*, ::) >:> model.thresholds).mapValues((v: Boolean) =>
+          if (v) 1.0 else 0.0)
+      }
 
-    override def isFitted(model: Binarizer): Boolean = true
+      xCopy
+    }
   }
 }

--- a/src/main/scala/io/picnicml/doddlemodel/preprocessing/Binarizer.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/preprocessing/Binarizer.scala
@@ -5,8 +5,8 @@ import io.picnicml.doddlemodel.data.Feature.FeatureIndex
 import io.picnicml.doddlemodel.data.{Features, RealVector}
 import io.picnicml.doddlemodel.typeclasses.Transformer
 
-case class Binarizer private (private val thresholds: RealVector,
-                              private val featureIndex: FeatureIndex)
+case class Binarizer private (private val featureIndex: FeatureIndex,
+                              private val thresholds: RealVector)
 
 object Binarizer {
 
@@ -14,14 +14,14 @@ object Binarizer {
     val numNumeric: Int = featureIndex.numerical.columnIndices.length
     require(numNumeric > 0, "There must be at least 1 numeric column in the given data")
     val thresholdsExtended = DenseVector.fill(numNumeric) {threshold}
-    new Binarizer(thresholdsExtended, featureIndex)
+    new Binarizer(featureIndex, thresholdsExtended)
   }
 
   def apply(thresholds: RealVector, featureIndex: FeatureIndex): Binarizer = {
     val numNumeric = featureIndex.numerical.columnIndices.length
     require(numNumeric > 0, "There must be at least 1 numeric column in the given data")
     require(numNumeric == thresholds.length, "A threshold should be given for every numerical column")
-    new Binarizer(thresholds, featureIndex)
+    new Binarizer(featureIndex, thresholds)
   }
 
   implicit lazy val ev: Transformer[Binarizer] = new Transformer[Binarizer] {

--- a/src/main/scala/io/picnicml/doddlemodel/preprocessing/Normalizer.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/preprocessing/Normalizer.scala
@@ -11,14 +11,13 @@ object Normalizer {
 
   def apply(norm: String = "l2"): Normalizer = {
     // TODO: expose norms for re-use
-    if(norm == "l2")
-      new Normalizer((x: Features) => sqrt(sum(pow(x, 2), Axis._1)))
-    else if(norm == "l1")
-      new Normalizer((x: Features) => sum(abs(x), Axis._1))
-    else if(norm == "max")
-      new Normalizer((x: Features) => max(abs(x), Axis._1))
-    else
-      throw new IllegalArgumentException("Unsupported norm")
+    val normFunction = norm match {
+      case "l2" => (x: Features) => sqrt(sum(pow(x, 2), Axis._1))
+      case "l1" => (x: Features) => sum(abs(x), Axis._1)
+      case "max" => (x: Features) => max(abs(x), Axis._1)
+      case _ => throw new IllegalArgumentException("Unsupported norm")
+    }
+    new Normalizer(normFunction)
   }
 
   implicit lazy val ev: Transformer[Normalizer] = new Transformer[Normalizer] {

--- a/src/main/scala/io/picnicml/doddlemodel/preprocessing/Normalizer.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/preprocessing/Normalizer.scala
@@ -5,8 +5,25 @@ import io.picnicml.doddlemodel.data.Features
 import io.picnicml.doddlemodel.preprocessing.Norms.{L2Norm, Norm}
 import io.picnicml.doddlemodel.typeclasses.Transformer
 
-case class Normalizer private (private val normFunction: Norm = L2Norm)
+case class Normalizer(normFunction: Norm = L2Norm)
 
+/** An immutable preprocessor that normalizes rows to unit norm according to specified norm function.
+  * See [[io.picnicml.doddlemodel.preprocessing.Norms]] for supported norm functions.
+  *
+  * @example Scale rows to unit norm according to L2 norm.
+  *   {{{
+  *     import io.picnicml.doddlemodel.preprocessing.Normalizer.ev
+  *     import io.picnicml.doddlemodel.preprocessing.Norms.L2Norm
+  *
+  *     val x = DenseMatrix(
+  *       List(1.0, 2.0, 2.0),
+  *       List(-2.0, 0.0, 0.0)
+  *     )
+  *     val l2Normalizer = Normalizer(L2Norm)
+  *     // Note: no fitting required
+  *     val xNormalized = ev.transform(l2Normalizer, x)
+  *   }}}
+  * */
 object Normalizer {
 
   implicit lazy val ev: Transformer[Normalizer] = new Transformer[Normalizer] {

--- a/src/main/scala/io/picnicml/doddlemodel/preprocessing/Normalizer.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/preprocessing/Normalizer.scala
@@ -1,0 +1,36 @@
+package io.picnicml.doddlemodel.preprocessing
+
+import breeze.linalg.{*, Axis, max, sum}
+import breeze.numerics.{abs, pow, sqrt}
+import io.picnicml.doddlemodel.data.{Features, RealVector}
+import io.picnicml.doddlemodel.typeclasses.Transformer
+
+case class Normalizer private (private val normFunction: Features => RealVector)
+
+object Normalizer {
+
+  def apply(norm: String = "l2"): Normalizer = {
+    // TODO: expose norms for re-use
+    if(norm == "l2")
+      new Normalizer((x: Features) => sqrt(sum(pow(x, 2), Axis._1)))
+    else if(norm == "l1")
+      new Normalizer((x: Features) => sum(abs(x), Axis._1))
+    else if(norm == "max")
+      new Normalizer((x: Features) => max(abs(x), Axis._1))
+    else
+      throw new IllegalArgumentException("Unsupported norm")
+  }
+
+  implicit lazy val ev: Transformer[Normalizer] = new Transformer[Normalizer] {
+    override def fit(model: Normalizer, x: Features): Normalizer = model
+
+    override protected def transformSafe(model: Normalizer, x: Features): Features = {
+      val rowNorms = model.normFunction(x)
+      // no-op for zero vector
+      rowNorms(rowNorms :== 0.0) := 1.0
+      x(::, *) /:/ rowNorms
+    }
+
+    override def isFitted(model: Normalizer): Boolean = true
+  }
+}

--- a/src/main/scala/io/picnicml/doddlemodel/preprocessing/Norms.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/preprocessing/Norms.scala
@@ -18,7 +18,7 @@ object Norms {
     override def apply(x: Features): RealVector = sqrt(sum(pow(x, 2), Axis._1))
   }
 
-  case object MaxNorm extends Norm {
+  final case object MaxNorm extends Norm {
     override def apply(x: Features): RealVector = max(abs(x), Axis._1)
   }
 }

--- a/src/main/scala/io/picnicml/doddlemodel/preprocessing/Norms.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/preprocessing/Norms.scala
@@ -1,0 +1,24 @@
+package io.picnicml.doddlemodel.preprocessing
+
+import breeze.linalg.{Axis, max, sum}
+import breeze.numerics.{abs, pow, sqrt}
+import io.picnicml.doddlemodel.data.{Features, RealVector}
+
+object Norms {
+
+  sealed trait Norm {
+    def apply(x: Features): RealVector
+  }
+
+  final case object L1Norm extends Norm {
+    override def apply(x: Features): RealVector = sum(abs(x), Axis._1)
+  }
+
+  final case object L2Norm extends Norm {
+    override def apply(x: Features): RealVector = sqrt(sum(pow(x, 2), Axis._1))
+  }
+
+  case object MaxNorm extends Norm {
+    override def apply(x: Features): RealVector = max(abs(x), Axis._1)
+  }
+}

--- a/src/main/scala/io/picnicml/doddlemodel/preprocessing/RangeScaler.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/preprocessing/RangeScaler.scala
@@ -1,0 +1,50 @@
+package io.picnicml.doddlemodel.preprocessing
+
+import breeze.linalg.{*, Axis, max, min}
+import cats.syntax.option._
+import io.picnicml.doddlemodel.data.Feature.FeatureIndex
+import io.picnicml.doddlemodel.data.{Features, RealVector}
+import io.picnicml.doddlemodel.typeclasses.Transformer
+import io.picnicml.doddlemodel.syntax.OptionSyntax._
+
+case class RangeScaler private (private val scale: Option[RealVector],
+                                private val minAdjustment: Option[RealVector],
+                                private val range: (Double, Double),
+                                private val featureIndex: FeatureIndex)
+
+object RangeScaler {
+
+  def apply(range: (Double, Double), featureIndex: FeatureIndex): RangeScaler = {
+    val numNumeric = featureIndex.numerical.columnIndices.length
+    require(numNumeric > 0, "There must be at least 1 numeric column in the given data")
+    require(range._2 > range._1, "Upper bound of range must be greater than lower bound")
+    RangeScaler(none, none, range, featureIndex)
+  }
+
+  implicit lazy val ev: Transformer[RangeScaler] = new Transformer[RangeScaler] {
+
+    override def fit(model: RangeScaler, x: Features): RangeScaler = {
+      val numericColsOnly = x(::, model.featureIndex.numerical.columnIndices).toDenseMatrix
+      val (colMax: RealVector, colMin: RealVector) =
+        (max(numericColsOnly, Axis._0).inner, min(numericColsOnly, Axis._0).inner)
+      val dataRange = colMax - colMin
+      // avoid division by zero for constant features (max == min)
+      dataRange(dataRange :== 0.0) := 1.0
+
+      val scale = (model.range._2 - model.range._1) / dataRange
+      val minAdjustment = model.range._1 - (colMin *:* scale)
+
+      model.copy(scale.some, minAdjustment.some)
+    }
+
+    override protected def transformSafe(model: RangeScaler, x: Features): Features = {
+      val numericColsOnly = x(::, model.featureIndex.numerical.columnIndices).toDenseMatrix
+      val colsScaled: Features = numericColsOnly(*, ::) *:* model.scale.getOrBreak
+      colsScaled(*, ::) +:+ model.minAdjustment.getOrBreak
+    }
+
+    override def isFitted(model: RangeScaler): Boolean =
+      model.scale.isDefined && model.minAdjustment.isDefined
+  }
+
+}

--- a/src/main/scala/io/picnicml/doddlemodel/preprocessing/RangeScaler.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/preprocessing/RangeScaler.scala
@@ -53,8 +53,8 @@ object RangeScaler {
     override def fit(model: RangeScaler, x: Features): RangeScaler = {
       val (lowerBound, upperBound) = model.range
       val numericColIndices = model.featureIndex.numerical.columnIndices
-      val (colMax: RealVector, colMin: RealVector) =
-        (max(x(::, numericColIndices), Axis._0).t, min(x(::, numericColIndices), Axis._0).t)
+      val colMax = max(x(::, numericColIndices), Axis._0).t.toDenseVector
+      val colMin = min(x(::, numericColIndices), Axis._0).t.toDenseVector
       val dataRange = colMax - colMin
       // avoid division by zero for constant features (max == min)
       dataRange(dataRange :== 0.0) := 1.0

--- a/src/test/scala/io/picnicml/doddlemodel/preprocessing/BinarizerTest.scala
+++ b/src/test/scala/io/picnicml/doddlemodel/preprocessing/BinarizerTest.scala
@@ -1,0 +1,51 @@
+package io.picnicml.doddlemodel.preprocessing
+
+import breeze.linalg.{DenseMatrix, DenseVector}
+import io.picnicml.doddlemodel.TestingUtils
+import io.picnicml.doddlemodel.data.Feature.{CategoricalFeature, FeatureIndex, NumericalFeature}
+import io.picnicml.doddlemodel.preprocessing.Binarizer.ev
+import org.scalatest.{FlatSpec, Matchers}
+
+class BinarizerTest extends FlatSpec with Matchers with TestingUtils {
+  val xMatrix = DenseMatrix(
+    List(0.0, 1.0, 0.0),
+    List(0.3, -1.0, 1.0),
+    List(-0.3, 2.0, 0.0)
+  )
+
+  "Binarizer" should "process the numerical columns by corresponding thresholds" in {
+    val featureIndex = FeatureIndex(List(NumericalFeature, NumericalFeature, CategoricalFeature))
+    val thresholds: DenseVector[Double] = DenseVector(0.0, -1.5)
+
+    val binarizer = Binarizer(thresholds, featureIndex)
+
+    breezeEqual(ev.transform(binarizer, xMatrix), DenseMatrix(
+      List(0.0, 1.0),
+      List(1.0, 1.0),
+      List(0.0, 1.0))) shouldBe true
+  }
+
+  it should "process all the numerical columns by a single threshold" in {
+    val featureIndex = FeatureIndex(List(NumericalFeature, NumericalFeature, NumericalFeature))
+    val threshold: Double = 0.5
+
+    val binarizer = Binarizer(threshold, featureIndex)
+
+    breezeEqual(ev.transform(binarizer, xMatrix), DenseMatrix(
+      List(0.0, 1.0, 0.0),
+      List(0.0, 0.0, 1.0),
+      List(0.0, 1.0, 0.0)
+    ))
+  }
+
+  it should "fail when there are insufficient/no numeric features in data" in {
+    val featureIndex1 = FeatureIndex(List(NumericalFeature, NumericalFeature, NumericalFeature))
+    val featureIndex2 = FeatureIndex(List(CategoricalFeature, CategoricalFeature, CategoricalFeature))
+    val thresholds: DenseVector[Double] = DenseVector(0.0, -1.5)
+
+    // 3 numeric columns vs 2 thresholds
+    an [IllegalArgumentException] should be thrownBy Binarizer(thresholds, featureIndex1)
+    // 0 numeric columns
+    an [IllegalArgumentException] should be thrownBy Binarizer(thresholds, featureIndex2)
+  }
+}

--- a/src/test/scala/io/picnicml/doddlemodel/preprocessing/NormalizerTest.scala
+++ b/src/test/scala/io/picnicml/doddlemodel/preprocessing/NormalizerTest.scala
@@ -26,7 +26,8 @@ class NormalizerTest extends FlatSpec with Matchers with TestingUtils {
         List(0.3333, 0.6666, 0.6666),
         List(-0.6666, 0.6666, 0.3333),
         List(-1.0, 0.0, 0.0)
-      )) shouldBe true
+      )
+    ) shouldBe true
 
     breezeEqual(ev.transform(l1Normalizer, x),
       DenseMatrix(

--- a/src/test/scala/io/picnicml/doddlemodel/preprocessing/NormalizerTest.scala
+++ b/src/test/scala/io/picnicml/doddlemodel/preprocessing/NormalizerTest.scala
@@ -1,0 +1,53 @@
+package io.picnicml.doddlemodel.preprocessing
+
+import breeze.linalg.DenseMatrix
+import io.picnicml.doddlemodel.TestingUtils
+import io.picnicml.doddlemodel.preprocessing.Normalizer.ev
+import org.scalactic.{Equality, TolerantNumerics}
+import org.scalatest.{FlatSpec, Matchers}
+
+class NormalizerTest extends FlatSpec with Matchers with TestingUtils {
+
+  implicit val doubleTolerance: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(1e-4)
+
+  "Normalizer" should "scale rows to unit norm using various norms" in {
+    val xMatrix = DenseMatrix(
+      List(1.0, 2.0, 2.0),
+      List(-1.0, 1.0, 0.5),
+      List(-2.0, 0.0, 0.0)
+    )
+    val l2Normalizer = Normalizer()
+    val l1Normalizer = Normalizer("l1")
+    val maxNormalizer = Normalizer("max")
+
+    breezeEqual(ev.transform(l2Normalizer, xMatrix), DenseMatrix(
+      List(0.3333, 0.6666, 0.6666),
+      List(-0.6666, 0.6666, 0.3333),
+      List(-1.0, 0.0, 0.0)
+    )) shouldBe true
+
+    breezeEqual(ev.transform(l1Normalizer, xMatrix), DenseMatrix(
+      List(0.2, 0.4, 0.4),
+      List(-0.4, 0.4, 0.2),
+      List(-1.0, 0.0, 0.0)
+    )) shouldBe true
+
+    breezeEqual(ev.transform(maxNormalizer, xMatrix), DenseMatrix(
+      List(0.5, 1.0, 1.0),
+      List(-1.0, 1.0, 0.5),
+      List(-1.0, 0.0, 0.0)
+    )) shouldBe true
+  }
+
+  it should "handle rows with zero norm" in {
+    val l2Normalizer = Normalizer()
+    val xMatrix = DenseMatrix(
+      List(0.0, 0.0, 0.0),
+      List(0.0, 3.0, 4.0)
+    )
+    breezeEqual(ev.transform(l2Normalizer, xMatrix), DenseMatrix(
+      List(0.0, 0.0, 0.0),
+      List(0.0, 0.6, 0.8)
+    )) shouldBe true
+  }
+}

--- a/src/test/scala/io/picnicml/doddlemodel/preprocessing/NormalizerTest.scala
+++ b/src/test/scala/io/picnicml/doddlemodel/preprocessing/NormalizerTest.scala
@@ -3,6 +3,7 @@ package io.picnicml.doddlemodel.preprocessing
 import breeze.linalg.DenseMatrix
 import io.picnicml.doddlemodel.TestingUtils
 import io.picnicml.doddlemodel.preprocessing.Normalizer.ev
+import io.picnicml.doddlemodel.preprocessing.Norms.{L1Norm, MaxNorm}
 import org.scalactic.{Equality, TolerantNumerics}
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -11,43 +12,50 @@ class NormalizerTest extends FlatSpec with Matchers with TestingUtils {
   implicit val doubleTolerance: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(1e-4)
 
   "Normalizer" should "scale rows to unit norm using various norms" in {
-    val xMatrix = DenseMatrix(
+    val x = DenseMatrix(
       List(1.0, 2.0, 2.0),
       List(-1.0, 1.0, 0.5),
       List(-2.0, 0.0, 0.0)
     )
     val l2Normalizer = Normalizer()
-    val l1Normalizer = Normalizer("l1")
-    val maxNormalizer = Normalizer("max")
+    val l1Normalizer = Normalizer(L1Norm)
+    val maxNormalizer = Normalizer(MaxNorm)
 
-    breezeEqual(ev.transform(l2Normalizer, xMatrix), DenseMatrix(
-      List(0.3333, 0.6666, 0.6666),
-      List(-0.6666, 0.6666, 0.3333),
-      List(-1.0, 0.0, 0.0)
-    )) shouldBe true
+    breezeEqual(ev.transform(l2Normalizer, x),
+      DenseMatrix(
+        List(0.3333, 0.6666, 0.6666),
+        List(-0.6666, 0.6666, 0.3333),
+        List(-1.0, 0.0, 0.0)
+      )) shouldBe true
 
-    breezeEqual(ev.transform(l1Normalizer, xMatrix), DenseMatrix(
-      List(0.2, 0.4, 0.4),
-      List(-0.4, 0.4, 0.2),
-      List(-1.0, 0.0, 0.0)
-    )) shouldBe true
+    breezeEqual(ev.transform(l1Normalizer, x),
+      DenseMatrix(
+        List(0.2, 0.4, 0.4),
+        List(-0.4, 0.4, 0.2),
+        List(-1.0, 0.0, 0.0)
+      )
+    ) shouldBe true
 
-    breezeEqual(ev.transform(maxNormalizer, xMatrix), DenseMatrix(
-      List(0.5, 1.0, 1.0),
-      List(-1.0, 1.0, 0.5),
-      List(-1.0, 0.0, 0.0)
-    )) shouldBe true
+    breezeEqual(ev.transform(maxNormalizer, x),
+      DenseMatrix(
+        List(0.5, 1.0, 1.0),
+        List(-1.0, 1.0, 0.5),
+        List(-1.0, 0.0, 0.0)
+      )
+    ) shouldBe true
   }
 
   it should "handle rows with zero norm" in {
     val l2Normalizer = Normalizer()
-    val xMatrix = DenseMatrix(
+    val x = DenseMatrix(
       List(0.0, 0.0, 0.0),
       List(0.0, 3.0, 4.0)
     )
-    breezeEqual(ev.transform(l2Normalizer, xMatrix), DenseMatrix(
+    val xNormalizedExpected = DenseMatrix(
       List(0.0, 0.0, 0.0),
       List(0.0, 0.6, 0.8)
-    )) shouldBe true
+    )
+
+    breezeEqual(ev.transform(l2Normalizer, x), xNormalizedExpected) shouldBe true
   }
 }

--- a/src/test/scala/io/picnicml/doddlemodel/preprocessing/NormsTest.scala
+++ b/src/test/scala/io/picnicml/doddlemodel/preprocessing/NormsTest.scala
@@ -1,0 +1,33 @@
+package io.picnicml.doddlemodel.preprocessing
+
+import breeze.linalg.{DenseMatrix, DenseVector}
+import io.picnicml.doddlemodel.TestingUtils
+import org.scalactic.{Equality, TolerantNumerics}
+import org.scalatest.{FlatSpec, Matchers}
+
+class NormsTest extends FlatSpec with Matchers with TestingUtils {
+
+  implicit val doubleTolerance: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(1e-4)
+
+  private val x = DenseMatrix(
+    List(0.0, 0.0, 0.0),
+    List(1.0, 2.0, 2.0),
+    List(-2.0, 0.0, 0.0)
+  )
+
+  "Norms" should "calculate the L2 norm of each row" in {
+    val xExpected = DenseVector(0.0, 3.0, 2.0)
+    breezeEqual(Norms.L2Norm(x), xExpected) shouldBe true
+  }
+
+  "Norms" should "calculate the L1 norm of each row" in {
+    val xExpected = DenseVector(0.0, 5.0, 2.0)
+    breezeEqual(Norms.L1Norm(x), xExpected) shouldBe true
+  }
+
+  "Norms" should "calculate the max norm of each row" in {
+    val xExpected = DenseVector(0.0, 2.0, 2.0)
+    breezeEqual(Norms.MaxNorm(x), xExpected) shouldBe true
+  }
+
+}

--- a/src/test/scala/io/picnicml/doddlemodel/preprocessing/RangeScalerTest.scala
+++ b/src/test/scala/io/picnicml/doddlemodel/preprocessing/RangeScalerTest.scala
@@ -1,0 +1,31 @@
+package io.picnicml.doddlemodel.preprocessing
+
+import breeze.linalg.DenseMatrix
+import io.picnicml.doddlemodel.TestingUtils
+import io.picnicml.doddlemodel.data.Feature.{CategoricalFeature, FeatureIndex, NumericalFeature}
+import org.scalatest.{FlatSpec, Matchers}
+import io.picnicml.doddlemodel.preprocessing.RangeScaler.ev
+import org.scalactic.{Equality, TolerantNumerics}
+
+class RangeScalerTest extends FlatSpec with Matchers with TestingUtils {
+  implicit val doubleTolerance: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(1e-4)
+
+  "Range scaler" should "scale features to specified range" in {
+    val xMatrix: DenseMatrix[Double] = DenseMatrix(
+      List(-3.0, 2.0, 1.0),
+      List(-3.0, 3.0, 0.0),
+      List(-3.0, 0.0, 0.0),
+      List(-3.0, 5.0, 1.0)
+    )
+    val featureIndex = FeatureIndex(List(NumericalFeature, NumericalFeature, CategoricalFeature))
+    val rangeScaler = RangeScaler((0.0, 1.0), featureIndex)
+    val trainedRangeScaler = ev.fit(rangeScaler, xMatrix)
+    breezeEqual(ev.transform(trainedRangeScaler, xMatrix), DenseMatrix(
+      List(0.0, 0.4),
+      List(0.0, 0.6),
+      List(0.0, 0.0),
+      List(0.0, 1.0)
+    )) shouldBe true
+  }
+
+}

--- a/src/test/scala/io/picnicml/doddlemodel/preprocessing/RangeScalerTest.scala
+++ b/src/test/scala/io/picnicml/doddlemodel/preprocessing/RangeScalerTest.scala
@@ -20,30 +20,58 @@ class RangeScalerTest extends FlatSpec with Matchers with TestingUtils {
 
   "Range scaler" should "scale numerical features to specified range" in {
     val featureIndex = FeatureIndex(List(NumericalFeature, NumericalFeature, CategoricalFeature))
-    val rangeScaler = RangeScaler((0.0, 1.0), featureIndex)
-    val trainedRangeScaler = ev.fit(rangeScaler, x)
+    val rangeScaler1 = RangeScaler((0.0, 1.0), featureIndex)
+    val trainedRangeScaler1 = ev.fit(rangeScaler1, x)
+    val rangeScaler2 = RangeScaler((-5.0, 15.0), featureIndex)
+    val trainedRangeScaler2 = ev.fit(rangeScaler2, x)
 
-    val xScaledExpected = DenseMatrix(
-      List(0.0, 0.4, 1.0),
-      List(0.0, 0.6, 0.0),
-      List(0.0, 0.0, 0.0),
-      List(0.0, 1.0, 1.0)
-    )
-    breezeEqual(ev.transform(trainedRangeScaler, x), xScaledExpected) shouldBe true
+    breezeEqual(
+      ev.transform(trainedRangeScaler1, x),
+      DenseMatrix(
+        List(0.0, 0.4, 1.0),
+        List(0.0, 0.6, 0.0),
+        List(0.0, 0.0, 0.0),
+        List(0.0, 1.0, 1.0)
+      )
+    ) shouldBe true
+
+    breezeEqual(
+      ev.transform(trainedRangeScaler2, x),
+      DenseMatrix(
+        List(-5.0, 3.0, 1.0),
+        List(-5.0, 7.0, 0.0),
+        List(-5.0, -5.0, 0.0),
+        List(-5.0, 15.0, 1.0)
+      )
+    ) shouldBe true
   }
 
   it should "scale selected subset of numerical features to specified range" in {
     val featureIndex = FeatureIndex(List(NumericalFeature, NumericalFeature, CategoricalFeature))
-    val rangeScaler = RangeScaler((0.0, 1.0), featureIndex.subset(1 to 1))
-    val trainedRangeScaler = ev.fit(rangeScaler, x)
+    val rangeScaler1 = RangeScaler((0.0, 1.0), featureIndex.subset(1 to 1))
+    val trainedRangeScaler1 = ev.fit(rangeScaler1, x)
+    val rangeScaler2 = RangeScaler((-5.0, 15.0), featureIndex.subset(1 to 1))
+    val trainedRangeScaler2 = ev.fit(rangeScaler2, x)
 
-    val xScaledExpected = DenseMatrix(
-      List(-3.0, 0.4, 1.0),
-      List(-3.0, 0.6, 0.0),
-      List(-3.0, 0.0, 0.0),
-      List(-3.0, 1.0, 1.0)
-    )
-    breezeEqual(ev.transform(trainedRangeScaler, x), xScaledExpected) shouldBe true
+    breezeEqual(
+      ev.transform(trainedRangeScaler1, x),
+      DenseMatrix(
+        List(-3.0, 0.4, 1.0),
+        List(-3.0, 0.6, 0.0),
+        List(-3.0, 0.0, 0.0),
+        List(-3.0, 1.0, 1.0)
+      )
+    ) shouldBe true
+
+    breezeEqual(
+      ev.transform(trainedRangeScaler2, x),
+      DenseMatrix(
+        List(-3.0, 3.0, 1.0),
+        List(-3.0, 7.0, 0.0),
+        List(-3.0, -5.0, 0.0),
+        List(-3.0, 15.0, 1.0)
+      )
+    ) shouldBe true
   }
 
   it should "amount to no-op if there are no numerical features in data" in {

--- a/src/test/scala/io/picnicml/doddlemodel/preprocessing/RangeScalerTest.scala
+++ b/src/test/scala/io/picnicml/doddlemodel/preprocessing/RangeScalerTest.scala
@@ -3,29 +3,54 @@ package io.picnicml.doddlemodel.preprocessing
 import breeze.linalg.DenseMatrix
 import io.picnicml.doddlemodel.TestingUtils
 import io.picnicml.doddlemodel.data.Feature.{CategoricalFeature, FeatureIndex, NumericalFeature}
-import org.scalatest.{FlatSpec, Matchers}
 import io.picnicml.doddlemodel.preprocessing.RangeScaler.ev
 import org.scalactic.{Equality, TolerantNumerics}
+import org.scalatest.{FlatSpec, Matchers}
 
 class RangeScalerTest extends FlatSpec with Matchers with TestingUtils {
+
   implicit val doubleTolerance: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(1e-4)
 
-  "Range scaler" should "scale features to specified range" in {
-    val xMatrix: DenseMatrix[Double] = DenseMatrix(
-      List(-3.0, 2.0, 1.0),
-      List(-3.0, 3.0, 0.0),
-      List(-3.0, 0.0, 0.0),
-      List(-3.0, 5.0, 1.0)
-    )
+  private val x = DenseMatrix(
+    List(-3.0, 2.0, 1.0),
+    List(-3.0, 3.0, 0.0),
+    List(-3.0, 0.0, 0.0),
+    List(-3.0, 5.0, 1.0)
+  )
+
+  "Range scaler" should "scale numerical features to specified range" in {
     val featureIndex = FeatureIndex(List(NumericalFeature, NumericalFeature, CategoricalFeature))
     val rangeScaler = RangeScaler((0.0, 1.0), featureIndex)
-    val trainedRangeScaler = ev.fit(rangeScaler, xMatrix)
-    breezeEqual(ev.transform(trainedRangeScaler, xMatrix), DenseMatrix(
-      List(0.0, 0.4),
-      List(0.0, 0.6),
-      List(0.0, 0.0),
-      List(0.0, 1.0)
-    )) shouldBe true
+    val trainedRangeScaler = ev.fit(rangeScaler, x)
+
+    val xScaledExpected = DenseMatrix(
+      List(0.0, 0.4, 1.0),
+      List(0.0, 0.6, 0.0),
+      List(0.0, 0.0, 0.0),
+      List(0.0, 1.0, 1.0)
+    )
+    breezeEqual(ev.transform(trainedRangeScaler, x), xScaledExpected) shouldBe true
   }
 
+  it should "scale selected subset of numerical features to specified range" in {
+    val featureIndex = FeatureIndex(List(NumericalFeature, NumericalFeature, CategoricalFeature))
+    val rangeScaler = RangeScaler((0.0, 1.0), featureIndex.subset(1 to 1))
+    val trainedRangeScaler = ev.fit(rangeScaler, x)
+
+    val xScaledExpected = DenseMatrix(
+      List(-3.0, 0.4, 1.0),
+      List(-3.0, 0.6, 0.0),
+      List(-3.0, 0.0, 0.0),
+      List(-3.0, 1.0, 1.0)
+    )
+    breezeEqual(ev.transform(trainedRangeScaler, x), xScaledExpected) shouldBe true
+  }
+
+  it should "amount to no-op if there are no numerical features in data" in {
+    val featureIndex = FeatureIndex(List(CategoricalFeature, CategoricalFeature, CategoricalFeature))
+    val rangeScaler = RangeScaler((0.0, 1.0), featureIndex)
+    val trainedRangeScaler = ev.fit(rangeScaler, x)
+
+    breezeEqual(ev.transform(trainedRangeScaler, x), x) shouldBe true
+  }
 }


### PR DESCRIPTION
<!-- This is a pull request template. Please fill in the relevant details in the sections below. -->
##### Description of Changes
<!-- Don't forget to add reference to an existing issue if present. -->
Addresses #7. Implements 3 new preprocessors:
1. Binarizer: convert **numerical columns** into binary columns based on a threshold. Works with either a `Double` scalar or a `DenseVector[Double]`. In the second case, each value of vector represents a threshold for a separate column, e.g. 1st value is used as threshold for 1st numeric column.  
Motivated by [sklearn's Binarizer](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.Binarizer.html).

2. Normalizer: converts **rows** to unit norm. Currently, there are 3 norms supported (L1, L2, max). These should probably be exposed in some kind of distance module for further code reuse, I am open to ideas on where to put these norm functions.  
Motivated by [sklearn's Normalizer](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.Normalizer.html).

3. RangeScaler: converts **numerical columns** to a certain range, e.g. from 0 to 1.  
Motivated by [sklearn's MinMaxScaler](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MinMaxScaler.html) (_RangeScaler_ or _IntervalScaler_ seems like a more intuitive name to me, though I can change it if min-max scaling is a "standardized" name for this).



##### Includes
<!-- Mark the changes included in the PR. -->
- [X] Code changes
- [X] Tests
- [ ] Documentation
