### PR TITLE
Fix featureIndex.subset() api

### DIFF
--- a/src/main/scala/io/picnicml/doddlemodel/data/Feature.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/data/Feature.scala
@@ -31,18 +31,21 @@ object Feature {
       val subsetIndices = this.types.zipWithIndex.flatMap {
         case (t, i) => if (cls.isInstance(t)) i.some else none[Int]
       }
-      subset(subsetIndices)
+      subset(subsetIndices:_*)
     }
 
     def subset(names: String*): FeatureIndex = {
       val nameToIndex = this.names.zipWithIndex.toMap
-      subset(names.map(n => nameToIndex(n)).toIndexedSeq)
+      subset(names.map(n => nameToIndex(n)):_*)
     }
 
-    def subset(indices: IndexedSeq[Int]): FeatureIndex = new FeatureIndex(
-      indices.map(i => this.names(i)),
-      indices.map(i => this.types(i)),
-      indices.map(i => this.columnIndices(i))
+    def subset(indices: IndexedSeq[Int]): FeatureIndex = subset(indices:_*)
+
+    // DummyImplicit is needed to avoid the same type as String* after erasure
+    def subset(indices: Int*)(implicit di: DummyImplicit): FeatureIndex = new FeatureIndex(
+      indices.toIndexedSeq.map(i => this.names(i)),
+      indices.toIndexedSeq.map(i => this.types(i)),
+      indices.toIndexedSeq.map(i => this.columnIndices(i))
     )
 
     def drop(index: Int): FeatureIndex = new FeatureIndex(

--- a/src/test/scala/io/picnicml/doddlemodel/data/FeatureTest.scala
+++ b/src/test/scala/io/picnicml/doddlemodel/data/FeatureTest.scala
@@ -61,14 +61,24 @@ class FeatureTest extends FlatSpec with Matchers {
       NumericalFeature
     )
     val featureIndex = FeatureIndex(types)
-    val subset = featureIndex.subset(1 to 3)
-    subset.names shouldBe IndexedSeq("f1", "f2", "f3")
-    subset.types shouldBe IndexedSeq(
+
+    val subset0 = featureIndex.subset(1 to 3)
+    subset0.names shouldBe IndexedSeq("f1", "f2", "f3")
+    subset0.types shouldBe IndexedSeq(
       NumericalFeature,
       CategoricalFeature,
       CategoricalFeature
     )
-    subset.columnIndices shouldBe IndexedSeq(1, 2, 3)
+    subset0.columnIndices shouldBe IndexedSeq(1, 2, 3)
+
+    val subset1 = featureIndex.subset(3, 4, 5)
+    subset1.names shouldBe IndexedSeq("f3", "f4", "f5")
+    subset1.types shouldBe IndexedSeq(
+      CategoricalFeature,
+      NumericalFeature,
+      CategoricalFeature
+    )
+    subset1.columnIndices shouldBe IndexedSeq(3, 4, 5)
   }
 
   it should "drop a column" in {


### PR DESCRIPTION
<!-- This is a pull request template. Please fill in the relevant details in the sections below. -->
##### Description of Changes
<!-- Don't forget to add reference to an existing issue if present. -->
Fixes the api of the `subset()` method on `FeatureIndex`. It's now possible to use the following:
- `featureIndex.subset(0, 3, 8)`
- `featureIndex.subset("f0", "f3", "f8")`
- `featureIndex.subset(1 to 3)`

##### Includes
<!-- Mark the changes included in the PR. -->
- [x] Code changes
- [x] Tests
- [ ] Documentation
