### PR TITLE
Disable Codacy coverage upload when no token is set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,4 +18,6 @@ jobs:
             - ~/.m2
             - ~/.ivy2
           key: sbt-scala-cache-{{ checksum "build.sbt" }}
-      - run: cat /dev/null | sbt coverage +test coverageReport coverageAggregate codacyCoverage
+      - run: (test -n "$CODACY_PROJECT_TOKEN" &&
+          cat /dev/null | sbt coverage +test coverageReport coverageAggregate codacyCoverage) ||
+          cat /dev/null | sbt coverage +test coverageReport coverageAggregate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jobs:
             - ~/.m2
             - ~/.ivy2
           key: sbt-scala-cache-{{ checksum "build.sbt" }}
-      - run: (test -n "$CODACY_PROJECT_TOKEN" &&
-          cat /dev/null | sbt coverage +test coverageReport coverageAggregate codacyCoverage) ||
-          cat /dev/null | sbt coverage +test coverageReport coverageAggregate
+      - run: |
+          if [ -n "$CODACY_PROJECT_TOKEN" ]; then
+            cat /dev/null | sbt coverage +test coverageReport coverageAggregate codacyCoverage
+          else
+            cat /dev/null | sbt coverage +test coverageReport coverageAggregate
+          fi


### PR DESCRIPTION
<!-- This is a pull request template. Please fill in the relevant details in the sections below. -->
##### Description of Changes
Fixes #91.

Decided to use if-statements instead of shorter syntax because previously, the build would not fail if the token was set, but was invalid or there was something wrong with process of uploading coverage.  

The way I see it, it might be more useful if a build fails e.g. when something's wrong with the token, but I don't know if it's beneficial if Codacy API happens to be down and the build fails because of this. 
##### Includes
<!-- Mark the changes included in the PR. -->
- [X] Code changes
- [ ] Tests
- [ ] Documentation
