### PR TITLE
Merge multiple apply functions into ones with default parameters

### DIFF
--- a/src/main/scala/io/picnicml/doddlemodel/linear/LinearRegression.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/linear/LinearRegression.scala
@@ -18,10 +18,8 @@ case class LinearRegression private (lambda: Double, private val w: Option[RealV
 
 object LinearRegression {
 
-  def apply(): LinearRegression = LinearRegression(0, none)
-
-  def apply(lambda: Double): LinearRegression = {
-    require(lambda >= 0, "L2 regularization strength must be positive")
+  def apply(lambda: Double = 0.0): LinearRegression = {
+    require(lambda >= 0.0, "L2 regularization strength must be non-negative")
     LinearRegression(lambda, none)
   }
 

--- a/src/main/scala/io/picnicml/doddlemodel/linear/LogisticRegression.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/linear/LogisticRegression.scala
@@ -20,10 +20,8 @@ case class LogisticRegression private (lambda: Double, numClasses: Option[Int], 
 
 object LogisticRegression {
 
-  def apply(): LogisticRegression = LogisticRegression(0, none, none)
-
-  def apply(lambda: Double): LogisticRegression = {
-    require(lambda >= 0, "L2 regularization strength must be positive")
+  def apply(lambda: Double = 0.0): LogisticRegression = {
+    require(lambda >= 0.0, "L2 regularization strength must be non-negative")
     LogisticRegression(lambda, none, none)
   }
 

--- a/src/main/scala/io/picnicml/doddlemodel/linear/PoissonRegression.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/linear/PoissonRegression.scala
@@ -20,10 +20,8 @@ case class PoissonRegression private (lambda: Double, private val w: Option[Real
 
 object PoissonRegression {
 
-  def apply(): PoissonRegression = PoissonRegression(0, none)
-
-  def apply(lambda: Double): PoissonRegression = {
-    require(lambda >= 0, "L2 regularization strength must be positive")
+  def apply(lambda: Double = 0.0): PoissonRegression = {
+    require(lambda >= 0.0, "L2 regularization strength must be non-negative")
     PoissonRegression(lambda, none)
   }
 

--- a/src/main/scala/io/picnicml/doddlemodel/linear/SoftmaxClassifier.scala
+++ b/src/main/scala/io/picnicml/doddlemodel/linear/SoftmaxClassifier.scala
@@ -21,10 +21,8 @@ case class SoftmaxClassifier private (lambda: Double, numClasses: Option[Int], p
 
 object SoftmaxClassifier {
 
-  def apply(): SoftmaxClassifier = SoftmaxClassifier(0, none, none)
-
-  def apply(lambda: Double): SoftmaxClassifier = {
-    require(lambda > 0, "L2 regularization strength must be positive")
+  def apply(lambda: Double = 0.0): SoftmaxClassifier = {
+    require(lambda >= 0.0, "L2 regularization strength must be non-negative")
     SoftmaxClassifier(lambda, none, none)
   }
 


### PR DESCRIPTION
<!-- This is a pull request template. Please fill in the relevant details in the sections below. -->
##### Description of Changes
Some `apply` functions are unnecessarily duplicated and can be merged into single ones with default values.

Minor fixes included:
- default values for parameters
- change messages from "value must be positive" to "value must be non-negative" whenever `0` is a valid option
- fix wrong check in softmax logic, where `0` was not considered valid regularization strength

##### Includes
<!-- Mark the changes included in the PR. -->
- [X] Code changes
- [ ] Tests
- [ ] Documentation
